### PR TITLE
Add Kill Youkai With Knives datapack.

### DIFF
--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "d82b587c4f4593cefdd5e93a7d4326099235d3053230081b64aaaf7014af8bde"
+hash = "8c47a060393c59f1b79fe1d0d9785aa70c7363da18cc0a5415b773ec5f3b5434"
 
 [versions]
 minecraft = "1.21.1"

--- a/pack/resources/datapack/required/killyoukaiwithknives/data/killyoukaiwithknives/tags/block/timestasis_redstone_deactivators.json
+++ b/pack/resources/datapack/required/killyoukaiwithknives/data/killyoukaiwithknives/tags/block/timestasis_redstone_deactivators.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:light_gray_glazed_terracotta"
+  ]
+}

--- a/pack/resources/datapack/required/killyoukaiwithknives/pack.mcmeta
+++ b/pack/resources/datapack/required/killyoukaiwithknives/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "pack_format": 48,
+        "description": "Kill Youkai With Knives data"
+    }
+}


### PR DESCRIPTION
To prevent breaking existing redstone contraptions with the new functionality of Timestasis, I have added a tag to define which blocks will make redstone components above them delayed in Kill Youkai with Knives.

This has been set to Light Gray Glazed Terracotta, meaning that any repeaters/comparators not on that block will be unaffected.